### PR TITLE
Fix issue with infinite waiting on socket error

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,11 @@ var SeleniumBrowser = function (baseBrowserDecorator, args, logger) {
         log.info('Browser closed');
         self._done();
         done();
+      })
+      .catch(error => {
+        log.error('Browser closed with error:\n' + error.message + '\n' + error.stack);
+        self._done(error);
+        done();
       });
   });
 };


### PR DESCRIPTION
We faced with this issue on our build system. If 1 browser disconnects by timeout then build job will never be finished.

Error from logs:
```
{ Error: An unknown server-side error occurred while processing the command.
    at session("delete") - end.js:31:17
    at end() - index.js:37:20
  details: undefined,
  message: 'Session [20431CC8-D2AE-438F-9E29-17C699C70287] was terminated due to TIMEOUT',
  type: 'RuntimeError',
  seleniumStack: 
   { type: 'UnknownError',
     message: 'An unknown server-side error occurred while processing the command.',
     orgStatusMessage: 'Session [20431CC8-D2AE-438F-9E29-17C699C70287] was terminated due to TIMEOUT' } }
```
This commit fixes this issue.